### PR TITLE
Add Release Policy document

### DIFF
--- a/.dockerdev/Dockerfile
+++ b/.dockerdev/Dockerfile
@@ -1,0 +1,42 @@
+ARG RUBY_VERSION
+FROM ruby:$RUBY_VERSION-slim-buster
+
+ARG NODE_VERSION
+ARG BUNDLER_VERSION
+
+RUN apt-get update -qq \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
+    build-essential \
+    python2 \
+    curl \
+    git \
+  && rm -rf /var/cache/apt/lists/*
+
+RUN curl -sSL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash -
+
+RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrade && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
+    nodejs \
+  &&  rm -rf /var/lib/apt/lists/*
+
+RUN npm install --global gulp-cli yarn
+
+ENV APP_USER=solidusio_user \
+    LANG=C.UTF-8 \
+    BUNDLE_JOBS=4 \
+    BUNDLE_RETRY=3
+ENV GEM_HOME=/home/$APP_USER/gems
+ENV APP_HOME=/home/$APP_USER/app
+ENV PATH=$PATH:$GEM_HOME/bin
+
+RUN useradd -ms /bin/bash $APP_USER
+
+RUN gem update --system \
+  && gem install bundler:$BUNDLER_VERSION \
+  && chown -R $APP_USER:$(id -g $APP_USER) /home/$APP_USER/gems
+
+USER $APP_USER
+
+RUN mkdir -p /home/$APP_USER/history
+
+WORKDIR /home/$APP_USER/app

--- a/README.md
+++ b/README.md
@@ -23,3 +23,10 @@ Usage
 4. To build html and assets for production, run
 
         $ bin/middleman build
+
+Or use the available docker-compose environment:
+
+```bash
+docker-compose up -d
+docker-compose exec app bin/middleman server --bind-address 0.0.0.0
+```

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@ Based on [https://github.com/joshukraine/middleman-gulp](https://github.com/josh
 Requirements
 ------------
 
-* [Middleman 4.x][middleman-docs]
-* [Ruby 2.x][rbenv]
-* [Node 8.x][nvm]
-* [Gulp CLI][gulp-cli]
+* [Middleman 4.x](https://middlemanapp.com/)
+* [Ruby 2.7](https://www.ruby-lang.org)
+* [Node 14](https://nodejs.org/en/)
+* [Yarn](https://yarnpkg.com/)
+* [Gulp CLI](https://www.npmjs.com/package/gulp-cli)
 
 Usage
 -----

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.7'
+
+services:
+  app:
+    build:
+      context: .dockerdev
+      dockerfile: Dockerfile
+      args:
+        RUBY_VERSION: "2.7.1"
+        NODE_VERSION: 14
+        BUNDLER_VERSION: 2
+    image: solidusio
+    command: bash -c "(bundle check || bundle) && (yarn check || yarn install --check-files) && tail -f /dev/null"
+    environment:
+      HISTFILE: "/home/solidusio_user/history/bash_history"
+    ports:
+      - "${SERVER_PORT:-4567}:${SERVER_PORT:-4567}"
+    volumes:
+      - .:/home/solidusio_user/app:delegated
+      - bundle:/home/solidusio_user/gems:cached
+      - history:/home/solidusio_user/history:cached
+    tty: true
+    stdin_open: true
+    tmpfs:
+      - /tmp
+
+volumes:
+  bundle:
+  history:

--- a/source/assets/stylesheets/components/_blocks.scss
+++ b/source/assets/stylesheets/components/_blocks.scss
@@ -133,7 +133,7 @@
 }
 
 // Security page wrapper
-.security-block{
+.security-block, .release_policy-block {
   max-width: 680px;
   margin: 0 auto;
 

--- a/source/partials/_footer.erb
+++ b/source/partials/_footer.erb
@@ -43,6 +43,9 @@
             <a class="text-white" href="/security">Security</a>
           </li>
           <li class="footer-links-item">
+            <a class="text-white" href="/release_policy">Release policy</a>
+          </li>
+          <li class="footer-links-item">
             <a class="text-white" href="https://github.com/solidusio/solidus/blob/master/CHANGELOG.md" target="_blank">Product changelog</a>
           </li>
           <li class="footer-links-item">

--- a/source/partials/_header.erb
+++ b/source/partials/_header.erb
@@ -65,6 +65,8 @@
             <div class="dropdown-bottom">
               <div class="dropdown-bottom__list">
                 <a class="dropdown-item" href="/extensions">Extensions</a>
+                <a class="dropdown-item" href="/security">Security</a>
+                <a class="dropdown-item" href="/release_policy">Release Policy</a>
                 <a class="dropdown-item" href="/partners/#become-a-partner">Become a Partner</a>
               </div>
               <div class="dropdown-bottom__list">

--- a/source/release_policy.html.erb
+++ b/source/release_policy.html.erb
@@ -1,0 +1,141 @@
+---
+title: Release policy
+description: Solidus follows semantic versioning and tries to keep a cadence for new releases so that users can have clear expectations.
+---
+
+<div class="content-block container">
+  <div class="release_policy-block">
+    <h1 class="title">Release policy</h1>
+
+    <div class="mb-4 mb-md-6">
+      <p class="lead">
+        This document presents the Solidus team's commitment to the release
+        cadence and policy for new Solidus releases. Users should take that as
+        soft guidelines and not as carved in stone. We might modify it to
+        accommodate the current state of development. On top of that, we're an
+        Open Source project with limited resources. Nonetheless, we expect that
+        will help Solidus users have a sense of when new features will be
+        available and plan upgrades in advance.
+      </p>
+
+      <p class="lead">
+        Solidus is in strict compliance with <a href="https://semver.org/">Semantic Versioning</a>.
+      </p>
+
+      <p class="lead">
+        <em>The used examples for version numbers don't need to correspond to
+        actual Solidus releases.</em>
+      </p>
+
+      <h2>Patch versions: releases on backports</h2>
+
+      <p>
+        <em>For example, a new patch release is transitioning from v3.2.0 to v3.2.1.</em>
+      </p>
+
+      <p>
+        Solidus releases a new patch version for a given minor whenever <strong>something is backported</strong>.
+      </p>
+
+      <p>
+        A new patch version only contains bug or security fixes. Most of the
+        time, this is done backward compatible, but it could introduce a
+        breaking change if there's no other way to fix an issue.
+      </p>
+
+      <p>
+        The backport policy is not strict, but users should expect all security
+        issues and sensible bugs to be backported to maintained versions.
+      </p>
+
+      <h2>Minor versions: quarterly releases</h2>
+
+      <p>
+        <em>For example, a new minor release is transitioning from v3.2.1 to v3.3.0.</em>
+      </p>
+
+      <p>
+        The Solidus team will evaluate releasing a new minor <strong>every quarter</strong>.
+      </p>
+
+      <p>
+        A new minor version can contain new features and bug or security fixes,
+        but it'll always add them in a backward compatible way. Deprecation
+        warnings are expected, but stores should keep working as before without
+        changes to the application code as long as users run the update
+        instructions.
+      </p>
+
+      <p>
+        See the <a href="#last_minor_before_major">last minor before every major
+        section</a>.
+      </p>
+
+      <h2>Major versions: every two years</h2>
+
+      <p>
+        <em>For example, a new major release is transitioning from v3.2.0 to
+        v4.0.0.</em>
+      </p>
+
+      <p>
+        Solidus aims to release a new major version at least <strong>every two
+        years</strong>.
+      </p>
+
+      <p>
+        A new major version contains breaking changes, and deprecated code is
+        removed.
+      </p>
+
+      <p>
+        See the <a href="#last_minor_before_major">last minor before every major
+        section</a>.
+      </p>
+
+      <h2 id="last_minor_before_major">Last minor before every major</h2>
+
+      <p>
+        <em>For example, the last minor before a major is v3.2.10 if the next release is v4.0.0.</em>
+      </p>
+
+      <p>
+        The final minor version in a major series (e.g., v3.2.10) and the first
+        one in the next (e.g., v4.0.0) are identical, besides removing
+        deprecated code.
+      </p>
+
+      <p>
+        All the deprecation warnings on the last minor version are removed in the next
+        major, and the application code is expected to comply. That means an application
+        that has been updated to the latest minor and adapted to avoid any deprecation
+        warning should keep working on the first minor release of the next series.
+      </p>
+
+      <p>
+        There could be exceptions when there's no way to introduce a new feature
+        without deprecating old behavior first, but that should be well
+        documented in the <a href="#changelog">Changelog</a>.
+      </p>
+
+      <p>
+        Master is frozen after the final minor version in a series and until the next
+        major is released. Both releases should happen very close in time.
+      </p>
+
+      <h2 id="changelog">Changelog</h2>
+
+      <p>
+        The <a
+        href="https://github.com/solidusio/solidus/blob/master/CHANGELOG.md">Changelog
+        in Solidus' master branch</a> is the unique source of truth for the
+        changes made to the project.
+      </p>
+
+      <p>
+        It shouldn't be expected for the Changelog files in other branches in
+        the repository or packaged gems to be complete.
+      </p>
+    </div>
+  </div>
+</div>

--- a/source/release_policy.html.erb
+++ b/source/release_policy.html.erb
@@ -34,7 +34,8 @@ description: Solidus follows semantic versioning and tries to keep a cadence for
       </p>
 
       <p>
-        Solidus releases a new patch version for a given minor whenever <strong>something is backported</strong>.
+      Solidus releases a new patch version for a given minor whenever
+      <strong>something is <a href="/security">backported</a></strong>.
       </p>
 
       <p>

--- a/source/security.html.erb
+++ b/source/security.html.erb
@@ -23,7 +23,7 @@ preview_image: security.png
       <h2>Supported Versions</h2>
       <p>
         Solidus versions will receive security patches for 18 months after
-        their initial release.
+        their initial <a href="/release_policy">release</a>.
       </p>
       <p>
         The following table represents the latest versions with their release date,


### PR DESCRIPTION
Added the document about the intended release cadence for Solidus. We
cross-link it with the security page, as they're related.

We're also adding links to both the Security & Release Policy pages to the top
navigation.

We've taken the occasion to setup a docker-compose development environment, and
fix/update links on the README.

[solidusiopr.webm](https://user-images.githubusercontent.com/52650/194307262-df8d13ed-a531-4db9-ad22-ffe1c69140b2.webm)

