### PR TITLE
Remove CI status from extensions page

### DIFF
--- a/source/partials/_extension.html.erb
+++ b/source/partials/_extension.html.erb
@@ -23,16 +23,6 @@
       <p><%= extension.description %></p>
     </div>
 
-    <div class="extension-ci">
-      <% extension.ci.build_statuses(versions: versions).each_pair do |version, build| %>
-        <%= partial 'partials/extension/build_status', locals: {
-            extension: extension,
-            version: version,
-            build: build,
-        } %>
-      <% end %>
-    </div>
-
     <div class="extension-meta align-items-center">
       <div class="extension-org">
         <img class="extension-org-logo rounded-circle" src="<%= extension.repo_org_image_url %>">


### PR DESCRIPTION
## Summary

It is too fragile and often broken. Considering we are going to redesign the website soon, let's revisit it later if we still need it.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
